### PR TITLE
fix: pass auth token during manifest discovery

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -202,7 +202,7 @@ export class SurfClient {
     const baseUrl = url.replace(/\/$/, '');
     const fetchFn = options?.fetch ?? globalThis.fetch;
     const timeout = options?.discoverTimeout ?? 5000;
-    const manifest = await discoverManifest(baseUrl, fetchFn, timeout);
+    const manifest = await discoverManifest(baseUrl, fetchFn, timeout, options?.auth);
     return new SurfClient(manifest, { baseUrl, ...options, fetch: fetchFn });
   }
 
@@ -324,7 +324,7 @@ export class SurfClient {
   async checkForUpdates(): Promise<UpdateCheckResult & { manifest?: SurfManifest }> {
     const fetchFn = (this.http as unknown as { fetch: typeof globalThis.fetch }).fetch ?? globalThis.fetch;
     try {
-      const fresh = await discoverManifest(this.baseUrl, fetchFn);
+      const fresh = await discoverManifest(this.baseUrl, fetchFn, undefined, this.auth);
       const changed = fresh.checksum !== this.manifest.checksum;
       return { changed, checksum: fresh.checksum, ...(changed ? { manifest: fresh } : {}) };
     } catch {

--- a/packages/client/src/discovery.ts
+++ b/packages/client/src/discovery.ts
@@ -8,15 +8,21 @@ export async function discoverManifest(
   baseUrl: string,
   fetchFn: typeof globalThis.fetch = globalThis.fetch,
   timeoutMs = 5000,
+  auth?: string,
 ): Promise<SurfManifest> {
   const url = new URL('/.well-known/surf.json', baseUrl);
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
+  const baseHeaders: Record<string, string> = {};
+  if (auth) {
+    baseHeaders['Authorization'] = `Bearer ${auth}`;
+  }
+
   try {
     const response = await fetchFn(url.toString(), {
-      headers: { Accept: 'application/json' },
+      headers: { Accept: 'application/json', ...baseHeaders },
       signal: controller.signal,
     });
 
@@ -31,7 +37,7 @@ export async function discoverManifest(
     // Fallback: try HTML <meta name="surf" content="..."> discovery
     const htmlUrl = new URL('/', baseUrl);
     const htmlResp = await fetchFn(htmlUrl.toString(), {
-      headers: { Accept: 'text/html' },
+      headers: { Accept: 'text/html', ...baseHeaders },
       signal: controller.signal,
     });
 
@@ -43,7 +49,7 @@ export async function discoverManifest(
       if (match?.[1]) {
         const manifestUrl = new URL(match[1], baseUrl);
         const mResp = await fetchFn(manifestUrl.toString(), {
-          headers: { Accept: 'application/json' },
+          headers: { Accept: 'application/json', ...baseHeaders },
           signal: controller.signal,
         });
         if (mResp.ok) {

--- a/packages/client/tests/discovery.test.ts
+++ b/packages/client/tests/discovery.test.ts
@@ -69,6 +69,84 @@ describe('discoverManifest', () => {
     expect(manifest.name).toBe('TestShop');
   });
 
+  it('passes Authorization header when auth token is provided', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    const mockFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      if (headers) capturedHeaders.push({ ...headers });
+      if (url.includes('/.well-known/surf.json')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => testManifest,
+          text: async () => JSON.stringify(testManifest),
+        };
+      }
+      return { ok: false, status: 404 };
+    }) as unknown as typeof globalThis.fetch;
+
+    await discoverManifest('http://localhost:3000', mockFetch, 5000, 'my-secret-token');
+
+    expect(capturedHeaders.length).toBeGreaterThanOrEqual(1);
+    expect(capturedHeaders[0]['Authorization']).toBe('Bearer my-secret-token');
+  });
+
+  it('does not send Authorization header when auth is not provided', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    const mockFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      if (headers) capturedHeaders.push({ ...headers });
+      if (url.includes('/.well-known/surf.json')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => testManifest,
+          text: async () => JSON.stringify(testManifest),
+        };
+      }
+      return { ok: false, status: 404 };
+    }) as unknown as typeof globalThis.fetch;
+
+    await discoverManifest('http://localhost:3000', mockFetch);
+
+    expect(capturedHeaders.length).toBeGreaterThanOrEqual(1);
+    expect(capturedHeaders[0]['Authorization']).toBeUndefined();
+  });
+
+  it('passes Authorization header to all fetch calls including fallback', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    let callCount = 0;
+    const mockFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      callCount++;
+      const headers = init?.headers as Record<string, string> | undefined;
+      if (headers) capturedHeaders.push({ ...headers });
+      if (url.includes('/.well-known/surf.json') && callCount === 1) {
+        return { ok: false, status: 404, statusText: 'Not Found' };
+      }
+      if (url.endsWith('/')) {
+        return {
+          ok: true,
+          text: async () => `<html><head><meta name="surf" content="/api/surf.json"></head></html>`,
+        };
+      }
+      if (url.includes('/api/surf.json')) {
+        return {
+          ok: true,
+          json: async () => testManifest,
+        };
+      }
+      return { ok: false, status: 404, statusText: 'Not Found' };
+    }) as unknown as typeof globalThis.fetch;
+
+    await discoverManifest('http://localhost:3000', mockFetch, 5000, 'my-secret-token');
+
+    // All three fetch calls should have the auth header
+    expect(capturedHeaders.length).toBe(3);
+    for (const headers of capturedHeaders) {
+      expect(headers['Authorization']).toBe('Bearer my-secret-token');
+    }
+  });
+
   it('throws when manifest cannot be found anywhere', async () => {
     const mockFetch = vi.fn(async (url: string) => {
       if (url.endsWith('/')) {


### PR DESCRIPTION
## Summary

Fixes `SurfClient.discover()` to pass the auth token when fetching the manifest, enabling discovery of `auth: hidden` commands.

## Changes

- Updated `discoverManifest()` to accept optional `auth` parameter
- Added `Authorization: Bearer` header to all manifest fetch calls (including HTML meta fallback) when auth is provided
- Updated `SurfClient.discover()` to forward `options.auth` to `discoverManifest()`
- Updated `checkForUpdates()` to forward `this.auth` to `discoverManifest()`
- Added 3 tests for authenticated discovery

## Testing

- New tests verify auth header is passed/omitted correctly
- All 7 tests passing

Fixes hauselabs/surf#47