### PR TITLE
feat(client): add SurfClient.setAuth() for token rotation

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -167,7 +167,7 @@ export class SurfClient {
   readonly manifest: SurfManifest;
   private readonly http: HttpTransport;
   private readonly baseUrl: string;
-  private readonly auth?: string;
+  private auth?: string;
   private readonly retryConfig?: RetryConfig;
   private readonly cache?: ResponseCache;
   private readonly surfBasePath: string;
@@ -221,6 +221,17 @@ export class SurfClient {
   /** Get a specific command definition. */
   command(name: string): ManifestCommand | undefined {
     return this.manifest.commands[name];
+  }
+
+  /**
+   * Update the auth token at runtime.
+   *
+   * Useful for OAuth2 token rotation — the new token is used for all
+   * subsequent HTTP requests and WebSocket messages without reconnecting.
+   */
+  setAuth(token: string | undefined): void {
+    this.auth = token;
+    this.http.setAuth(token);
   }
 
   /**

--- a/packages/client/src/transport/http.ts
+++ b/packages/client/src/transport/http.ts
@@ -19,7 +19,7 @@ const DEFAULT_EXECUTE_PATH = '/surf/execute';
  */
 export class HttpTransport {
   private readonly baseUrl: string;
-  private readonly auth?: string;
+  private auth?: string;
   private readonly fetch: typeof globalThis.fetch;
   private readonly executePath: string;
 
@@ -28,6 +28,11 @@ export class HttpTransport {
     this.auth = options.auth;
     this.fetch = options.fetch;
     this.executePath = options.basePath ?? DEFAULT_EXECUTE_PATH;
+  }
+
+  /** Update the auth token used for subsequent requests. */
+  setAuth(token: string | undefined): void {
+    this.auth = token;
   }
 
   async execute(


### PR DESCRIPTION
Adds `setAuth(token)` method to `SurfClient`, allowing auth token updates after construction. Supports OAuth2 token rotation without recreating the client.

## Changes

- Remove `readonly` from `SurfClient.auth` property
- Add `SurfClient.setAuth(token: string | undefined): void` method
- Add `HttpTransport.setAuth()` to propagate token changes to the HTTP transport
- Pipeline method already reads `this.auth` directly, so it picks up changes automatically

All 121 existing tests pass.

Fixes #56