### PR TITLE
fix(react,core): deep merge patches in useSurfState and live.patchState

### DIFF
--- a/packages/core/src/deepMerge.ts
+++ b/packages/core/src/deepMerge.ts
@@ -1,0 +1,37 @@
+/**
+ * Check if a value is a plain object (not an array, null, Date, RegExp, etc.).
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Recursively deep-merge `source` into `target`.
+ *
+ * - Plain objects are merged recursively.
+ * - Arrays replace the target value (no concatenation).
+ * - Primitives, null, and non-plain objects replace the target value.
+ *
+ * Returns a new object — neither `target` nor `source` is mutated.
+ */
+export function deepMerge<T extends Record<string, unknown>>(
+  target: T,
+  source: Record<string, unknown>,
+): T {
+  const result: Record<string, unknown> = { ...target };
+
+  for (const key of Object.keys(source)) {
+    const srcVal = source[key];
+    const tgtVal = result[key];
+
+    if (isPlainObject(srcVal) && isPlainObject(tgtVal)) {
+      result[key] = deepMerge(tgtVal, srcVal);
+    } else {
+      result[key] = srcVal;
+    }
+  }
+
+  return result as T;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@
 
 export { createSurf } from './surf.js';
 export type { SurfInstance, SurfLive } from './surf.js';
+export { deepMerge } from './deepMerge.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/packages/core/src/surf.ts
+++ b/packages/core/src/surf.ts
@@ -8,6 +8,7 @@ import type { SurfMiddleware } from './middleware.js';
 import { CommandRegistry } from './commands.js';
 import { generateManifest } from './manifest.js';
 import { InMemorySessionStore } from './session.js';
+import { deepMerge } from './deepMerge.js';
 import { EventBus } from './events.js';
 import { createAuthMiddleware } from './auth.js';
 import {
@@ -226,10 +227,10 @@ export async function createSurf(config: SurfConfig): Promise<SurfInstance> {
           eventBus.emitToChannel('surf:state', { channel: channelId, state, version }, channelId);
         },
         patchState(channelId: string, patch: unknown) {
-          // Apply shallow merge to cached state
+          // Apply deep merge to cached state
           const current = channelStates.get(channelId);
           if (current && typeof current === 'object' && patch && typeof patch === 'object') {
-            channelStates.set(channelId, { ...(current as Record<string, unknown>), ...(patch as Record<string, unknown>) });
+            channelStates.set(channelId, deepMerge(current as Record<string, unknown>, patch as Record<string, unknown>));
           }
           const version = nextVersion(channelId);
           eventBus.emitToChannel('surf:patch', { channel: channelId, patch, version }, channelId);

--- a/packages/react/src/deepMerge.ts
+++ b/packages/react/src/deepMerge.ts
@@ -1,0 +1,37 @@
+/**
+ * Check if a value is a plain object (not an array, null, Date, RegExp, etc.).
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Recursively deep-merge `source` into `target`.
+ *
+ * - Plain objects are merged recursively.
+ * - Arrays replace the target value (no concatenation).
+ * - Primitives, null, and non-plain objects replace the target value.
+ *
+ * Returns a new object — neither `target` nor `source` is mutated.
+ */
+export function deepMerge<T extends Record<string, unknown>>(
+  target: T,
+  source: Record<string, unknown>,
+): T {
+  const result: Record<string, unknown> = { ...target };
+
+  for (const key of Object.keys(source)) {
+    const srcVal = source[key];
+    const tgtVal = result[key];
+
+    if (isPlainObject(srcVal) && isPlainObject(tgtVal)) {
+      result[key] = deepMerge(tgtVal, srcVal);
+    } else {
+      result[key] = srcVal;
+    }
+  }
+
+  return result as T;
+}

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { SurfContext, type SurfContextValue, type EventCallback } from './context.js';
+import { deepMerge } from './deepMerge.js';
 
 /**
  * Access the Surf context. Throws if used outside SurfProvider.
@@ -72,7 +73,7 @@ interface PatchEventData {
  * Synced state hook that auto-updates from Surf Live broadcast events.
  *
  * Listens for `surf:state` events and updates local state when received.
- * Also supports `surf:patch` events for incremental updates (shallow merge).
+ * Also supports `surf:patch` events for incremental updates (deep merge).
  *
  * @param key - Optional key to filter state events (matches against channel name)
  * @param initialState - Initial state value
@@ -99,7 +100,7 @@ export function useSurfState<T>(key: string, initialState: T): [T, (value: T | (
     versionRef.current = typed.version;
     setState(prev => {
       if (typeof prev === 'object' && prev !== null && typeof typed.patch === 'object') {
-        return { ...prev, ...typed.patch } as T;
+        return deepMerge(prev as Record<string, unknown>, typed.patch) as T;
       }
       return prev;
     });


### PR DESCRIPTION
Replaces shallow spread merge with recursive deep merge for state patches. Arrays are replaced (not concatenated), primitives are overwritten, plain objects are recursively merged.

Fixes #67