### PR TITLE
feat(core): add runtime guard for un-awaited createSurf()

### DIFF
--- a/packages/core/src/adapters/fastify.ts
+++ b/packages/core/src/adapters/fastify.ts
@@ -6,6 +6,7 @@ import type {
 } from '../types.js';
 import { executePipeline } from '../transport/pipeline.js';
 import { createSseWriter, chunkEvent, doneEvent, errorEvent } from '../transport/sse.js';
+import { assertNotPromise } from '../errors.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -24,6 +25,7 @@ import { createSseWriter, chunkEvent, doneEvent, errorEvent } from '../transport
  * ```
  */
 export function fastifyPlugin(surf: SurfInstance) {
+  assertNotPromise(surf);
   const registry = surf.commands;
   const sessions = surf.sessions;
 

--- a/packages/core/src/adapters/hono.ts
+++ b/packages/core/src/adapters/hono.ts
@@ -5,6 +5,7 @@ import type {
   SurfResponse,
 } from '../types.js';
 import { executePipeline } from '../transport/pipeline.js';
+import { assertNotPromise } from '../errors.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -23,6 +24,7 @@ import { executePipeline } from '../transport/pipeline.js';
  * ```
  */
 function buildHonoApp(surf: SurfInstance, Hono: new () => any): any {
+  assertNotPromise(surf);
   const app = new Hono();
 
   const registry = surf.commands;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -64,3 +64,17 @@ export function internalError(message?: string): SurfError {
 export function notSupported(command: string): SurfError {
   return new SurfError('NOT_SUPPORTED', `Command not available: ${command}`, { command });
 }
+
+// ─── Guard rails ────────────────────────────────────────────────────────────
+
+/**
+ * Throws a clear error if the given value looks like a Promise (i.e. has a `.then` method).
+ * This catches the common mistake of forgetting to `await createSurf()`.
+ */
+export function assertNotPromise(surf: unknown): void {
+  if (surf && typeof (surf as { then?: unknown }).then === 'function') {
+    throw new Error(
+      'Did you forget to await createSurf()? Received a Promise instead of a SurfInstance.',
+    );
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,7 @@ export {
   internalError,
   notSupported,
   notFound,
+  assertNotPromise,
 } from './errors.js';
 
 // ─── Middleware ───────────────────────────────────────────────────────────────

--- a/packages/next/src/pages.ts
+++ b/packages/next/src/pages.ts
@@ -4,7 +4,7 @@ import type {
   PipelineRequest,
   SurfResponse,
 } from '@surfjs/core';
-import { executePipeline } from '@surfjs/core';
+import { executePipeline, assertNotPromise } from '@surfjs/core';
 import {
   getErrorStatus,
   extractAuth,
@@ -72,6 +72,7 @@ function headerValue(val: string | string[] | undefined): string | undefined {
 export function createSurfApiHandler(
   surf: SurfInstance,
 ): (req: PagesApiRequest, res: PagesApiResponse) => Promise<void> {
+  assertNotPromise(surf);
   const registry = surf.commands;
   const sessions = surf.sessions;
 


### PR DESCRIPTION
Adds a runtime assertion (`assertNotPromise`) to all framework adapters that throws a clear error if a Promise is passed instead of a SurfInstance. Catches the common mistake of forgetting to `await createSurf()`.

### Changes
- Added `assertNotPromise()` utility to `packages/core/src/errors.ts`
- Guard added at entry of: `buildHonoApp()`, `fastifyPlugin()`, `createSurfApiHandler()`
- Exported from `@surfjs/core` for external use
- All 121 tests pass, build clean

Fixes #60