### PR TITLE
feat(client,core): WebSocket reconnection + connection health monitoring

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,6 +2,7 @@ export { SurfClient, SurfClientError } from './client.js';
 export { discoverManifest } from './discovery.js';
 export { HttpTransport } from './transport/http.js';
 export { WebSocketTransport } from './transport/websocket.js';
+export type { ConnectionState, WebSocketTransportOptions } from './transport/websocket.js';
 export { WindowTransport } from './transport/window.js';
 
 export type {

--- a/packages/client/src/transport/websocket.ts
+++ b/packages/client/src/transport/websocket.ts
@@ -15,9 +15,33 @@ interface WebSocketLike {
   onmessage: ((ev: { data: string | Buffer }) => void) | null;
   onclose: ((ev: unknown) => void) | null;
   onerror: ((ev: unknown) => void) | null;
+  ping?: (data?: unknown, mask?: boolean, cb?: (err: Error) => void) => void;
 }
 
 const WS_OPEN = 1;
+
+/** Connection state for the WebSocket transport. */
+export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
+
+/** Options for configuring reconnection and health monitoring. */
+export interface WebSocketTransportOptions {
+  /** Enable auto-reconnect on disconnect. Default: true */
+  reconnect?: boolean;
+  /** Maximum number of reconnect attempts. Default: Infinity */
+  maxReconnectAttempts?: number;
+  /** Initial reconnect delay in ms. Default: 1000 */
+  reconnectDelay?: number;
+  /** Maximum reconnect delay in ms. Default: 16000 */
+  maxReconnectDelay?: number;
+  /** Interval for ping keepalive in ms. Default: 30000 */
+  pingInterval?: number;
+  /** Called when connection is lost. */
+  onDisconnect?: () => void;
+  /** Called when connection is re-established after a disconnect. */
+  onReconnect?: () => void;
+  /** Called when connection state changes. */
+  onStateChange?: (state: ConnectionState) => void;
+}
 
 /**
  * WebSocket transport for real-time Surf command execution and event streaming.
@@ -29,10 +53,54 @@ export class WebSocketTransport {
   private msgCounter = 0;
   private sessionId?: string;
 
+  // Reconnection state
+  private _state: ConnectionState = 'disconnected';
+  private connectUrl?: string;
+  private connectAuth?: string;
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private intentionalClose = false;
+
+  private readonly opts: Required<Omit<WebSocketTransportOptions, 'onDisconnect' | 'onReconnect' | 'onStateChange'>> & Pick<WebSocketTransportOptions, 'onDisconnect' | 'onReconnect' | 'onStateChange'>;
+
+  constructor(options?: WebSocketTransportOptions) {
+    this.opts = {
+      reconnect: options?.reconnect ?? true,
+      maxReconnectAttempts: options?.maxReconnectAttempts ?? Infinity,
+      reconnectDelay: options?.reconnectDelay ?? 1000,
+      maxReconnectDelay: options?.maxReconnectDelay ?? 16000,
+      pingInterval: options?.pingInterval ?? 30000,
+      onDisconnect: options?.onDisconnect,
+      onReconnect: options?.onReconnect,
+      onStateChange: options?.onStateChange,
+    };
+  }
+
+  /** Current connection state. */
+  get state(): ConnectionState {
+    return this._state;
+  }
+
+  private setState(state: ConnectionState): void {
+    if (this._state === state) return;
+    this._state = state;
+    this.opts.onStateChange?.(state);
+  }
+
   /**
    * Connect to a Surf WebSocket endpoint.
    */
   async connect(url: string, auth?: string): Promise<void> {
+    this.connectUrl = url;
+    this.connectAuth = auth;
+    this.intentionalClose = false;
+    this.setState('connecting');
+
+    return this.doConnect(url, auth);
+  }
+
+  private async doConnect(url: string, auth?: string): Promise<void> {
     return new Promise(async (resolve, reject) => {
       // Try browser WebSocket first, then Node ws
       const WsConstructor = typeof WebSocket !== 'undefined'
@@ -40,6 +108,7 @@ export class WebSocketTransport {
         : await this.getNodeWsAsync();
 
       if (!WsConstructor) {
+        this.setState('disconnected');
         reject(new Error('WebSocket not available. Install "ws" package for Node.js.'));
         return;
       }
@@ -48,9 +117,19 @@ export class WebSocketTransport {
       this.ws = ws;
 
       ws.onopen = () => {
+        const wasReconnecting = this._state === 'reconnecting';
+        this.setState('connected');
+        this.reconnectAttempts = 0;
+        this.startPing();
+
         if (auth) {
           ws.send(JSON.stringify({ type: 'auth', token: auth }));
         }
+
+        if (wasReconnecting) {
+          this.opts.onReconnect?.();
+        }
+
         resolve();
       };
 
@@ -71,18 +150,87 @@ export class WebSocketTransport {
       };
 
       ws.onerror = (ev) => {
-        reject(new Error(`WebSocket error: ${String(ev)}`));
+        // Only reject if this is the initial connection attempt
+        if (this._state === 'connecting') {
+          this.setState('disconnected');
+          reject(new Error(`WebSocket error: ${String(ev)}`));
+        }
       };
 
       ws.onclose = () => {
+        this.stopPing();
+
         // Reject all pending requests
         for (const [, pending] of this.pending) {
           pending.reject(new Error('WebSocket closed'));
         }
         this.pending.clear();
         this.ws = null;
+
+        if (this.intentionalClose) {
+          this.setState('disconnected');
+          return;
+        }
+
+        const wasConnected = this._state === 'connected' || this._state === 'reconnecting';
+        if (wasConnected) {
+          this.opts.onDisconnect?.();
+        }
+
+        this.setState('disconnected');
+
+        // Attempt reconnection
+        if (this.opts.reconnect && this.connectUrl && !this.intentionalClose) {
+          this.scheduleReconnect();
+        }
       };
     });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectAttempts >= this.opts.maxReconnectAttempts) return;
+
+    const delay = Math.min(
+      this.opts.reconnectDelay * Math.pow(2, this.reconnectAttempts),
+      this.opts.maxReconnectDelay,
+    );
+    this.reconnectAttempts++;
+    this.setState('reconnecting');
+
+    this.reconnectTimer = setTimeout(async () => {
+      this.reconnectTimer = null;
+      if (this.intentionalClose || !this.connectUrl) return;
+
+      try {
+        await this.doConnect(this.connectUrl, this.connectAuth);
+      } catch {
+        // doConnect failed, onclose will trigger another reconnect attempt
+      }
+    }, delay);
+  }
+
+  private startPing(): void {
+    this.stopPing();
+    if (this.opts.pingInterval <= 0) return;
+
+    this.pingTimer = setInterval(() => {
+      if (!this.ws || this.ws.readyState !== WS_OPEN) return;
+
+      // Use ws library's built-in ping if available (Node.js),
+      // otherwise send a JSON ping message
+      if (typeof this.ws.ping === 'function') {
+        this.ws.ping();
+      } else {
+        this.ws.send(JSON.stringify({ type: 'ping' }));
+      }
+    }, this.opts.pingInterval);
+  }
+
+  private stopPing(): void {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
   }
 
   /**
@@ -166,11 +314,18 @@ export class WebSocketTransport {
   }
 
   /**
-   * Close the WebSocket connection.
+   * Close the WebSocket connection. Stops reconnection.
    */
   close(): void {
+    this.intentionalClose = true;
+    this.stopPing();
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     this.ws?.close();
     this.ws = null;
+    this.setState('disconnected');
   }
 
   get connected(): boolean {

--- a/packages/core/src/transport/websocket.ts
+++ b/packages/core/src/transport/websocket.ts
@@ -10,22 +10,37 @@ interface WsTransportOptions {
   live?: LiveConfig;
   /** Get last known state for initial delivery on channel subscribe. */
   getChannelState?: (channelId: string) => { state: unknown; version: number } | undefined;
+  /** Interval for ping keepalive in ms. Default: 30000 */
+  pingInterval?: number;
+  /** Timeout for pong response in ms. Default: 10000 */
+  pongTimeout?: number;
 }
 
 interface WebSocketLike {
   on(event: 'message', cb: (data: Buffer | string) => void): void;
   on(event: 'close', cb: () => void): void;
   on(event: 'error', cb: (err: Error) => void): void;
+  on(event: 'pong', cb: () => void): void;
   send(data: string): void;
+  ping(data?: unknown, mask?: boolean, cb?: (err: Error) => void): void;
+  terminate(): void;
+  close(): void;
   readyState: number;
 }
 
 interface WebSocketServerLike {
   on(event: 'connection', cb: (ws: WebSocketLike) => void): void;
+  clients?: Set<WebSocketLike>;
 }
 
 // ws library constants
 const WS_OPEN = 1;
+
+/** Handle returned from attachWebSocket for graceful shutdown. */
+export interface WebSocketHandle {
+  /** Gracefully close all connections and stop ping intervals. */
+  close(): void;
+}
 
 /**
  * Attach Surf WebSocket handling to a ws WebSocketServer.
@@ -43,12 +58,47 @@ const WS_OPEN = 1;
 export function attachWebSocket(
   wss: WebSocketServerLike,
   options: WsTransportOptions,
-): void {
+): WebSocketHandle {
   const { registry, sessions, events, live } = options;
   const liveEnabled = live?.enabled === true;
   const maxChannels = live?.maxChannelsPerConnection ?? 10;
+  const pingIntervalMs = options.pingInterval ?? 30000;
+  const pongTimeoutMs = options.pongTimeout ?? 10000;
+
+  // Track all active connections for graceful shutdown
+  const activeConnections = new Set<WebSocketLike>();
+  const aliveFlags = new Map<WebSocketLike, boolean>();
+  let closed = false;
+
+  // Periodic ping to detect dead clients
+  const heartbeatInterval = pingIntervalMs > 0 ? setInterval(() => {
+    for (const ws of activeConnections) {
+      if (aliveFlags.get(ws) === false) {
+        // No pong received since last ping — terminate
+        ws.terminate();
+        continue;
+      }
+      aliveFlags.set(ws, false);
+      if (ws.readyState === WS_OPEN) {
+        ws.ping();
+      }
+    }
+  }, pingIntervalMs) : null;
 
   wss.on('connection', (ws) => {
+    if (closed) {
+      ws.close();
+      return;
+    }
+
+    activeConnections.add(ws);
+    aliveFlags.set(ws, true);
+
+    // Track pong responses for keepalive
+    ws.on('pong', () => {
+      aliveFlags.set(ws, true);
+    });
+
     let authToken: string | undefined;
     let sessionId: string | undefined;
     const unsubscribes: Array<() => void> = [];
@@ -81,6 +131,9 @@ export function attachWebSocket(
     subscribeToEvents();
 
     ws.on('message', async (raw) => {
+      // Any message counts as activity
+      aliveFlags.set(ws, true);
+
       let msg: WsIncomingMessage;
       try {
         msg = JSON.parse(typeof raw === 'string' ? raw : raw.toString('utf-8')) as WsIncomingMessage;
@@ -276,7 +329,9 @@ export function attachWebSocket(
       }
     });
 
-    ws.on('close', () => {
+    function cleanup(): void {
+      activeConnections.delete(ws);
+      aliveFlags.delete(ws);
       // Clean up all event subscriptions for this connection
       for (const unsub of unsubscribes) {
         unsub();
@@ -291,20 +346,24 @@ export function attachWebSocket(
       if (sessionId) {
         events.removeSession(sessionId);
       }
-    });
+    }
 
-    ws.on('error', () => {
-      for (const unsub of unsubscribes) {
-        unsub();
-      }
-      for (const unsub of channelUnsubscribes.values()) {
-        unsub();
-      }
-      channelUnsubscribes.clear();
-      subscribedChannels.clear();
-      if (sessionId) {
-        events.removeSession(sessionId);
-      }
-    });
+    ws.on('close', cleanup);
+    ws.on('error', cleanup);
   });
+
+  return {
+    close(): void {
+      closed = true;
+      if (heartbeatInterval) {
+        clearInterval(heartbeatInterval);
+      }
+      // Gracefully close all active connections
+      for (const ws of activeConnections) {
+        ws.close();
+      }
+      activeConnections.clear();
+      aliveFlags.clear();
+    },
+  };
 }


### PR DESCRIPTION
## Client
- Auto-reconnect with exponential backoff (1s→16s max, reset on success)
- Connection state tracking (`connecting`/`connected`/`disconnected`/`reconnecting`)
- `onDisconnect`/`onReconnect`/`onStateChange` callbacks
- Periodic ping for stale connection detection (30s default)
- `WebSocketTransportOptions` for full configurability

## Server
- Ping/pong keepalive (30s interval, terminate if no pong)
- `WebSocketHandle.close()` for graceful shutdown (close all clients, clear intervals)
- New connections rejected after shutdown

## Notes
- All 121 existing tests pass
- Build succeeds across all packages
- Backward-compatible: `WebSocketTransport` constructor accepts optional options
- Server `attachWebSocket()` now returns `WebSocketHandle` (previously void)

Fixes #64